### PR TITLE
Make eslint a dep, not a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
       "jest": true
     }
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "eslint": "^4",
+  },
+  "devDependencies": {
     "eslint-config-vue": "^2.0.2",
     "eslint-plugin-vue": "^2.1.0",
     "jest": "^20.0.3"


### PR DESCRIPTION
Eslint is a runtime dependency of this package if used via the flat format. This commit moves eslint into the dependency field.

I am using `aspect_rules_js`, which does not include transitive dependencies.


Error: Cannot find module 'eslint'
Require stack:
- /private/var/tmp/_bazel_tshadwell/f7d9bb6f07b31d1ba7eb0c999b8bb37b/sandbox/darwin-sandbox/3313/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/node_modules/.aspect_rules_js/eslint-plugin-only-error@1.0.2/node_modules/eslint-plugin-only-error/src/only-error.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
    at Module._load (node:internal/modules/cjs/loader:981:27)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/private/var/tmp/_bazel_tshadwell/f7d9bb6f07b31d1ba7eb0c999b8bb37b/sandbox/darwin-sandbox/3313/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/node_modules/.aspect_rules_js/eslint-plugin-only-error@1.0.2/node_modules/eslint-plugin-only-error/src/only-error.js:1:16)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:203:29)
INFO: From ESLint project/zemn.me/app/article/ESLint.article_typings.aspect_rules_lint.report: